### PR TITLE
stop sim when pressed reset

### DIFF
--- a/isaacsim_extension/exts/robotics.multiagent.mapping/robotics/multiagent/mapping/extension.py
+++ b/isaacsim_extension/exts/robotics.multiagent.mapping/robotics/multiagent/mapping/extension.py
@@ -8,9 +8,9 @@ from omni.isaac.core.utils.stage import add_reference_to_stage
 from .spawn import RobotSpawner
 from .file_manager import FileManager
 from .global_clock import GlobalClockGraph
+from .utils import reset_simulation_and_ros2
 
 import threading
-
 
 class RoboticsMultiagentMappingExtension(omni.ext.IExt):
     def on_startup(self, ext_id):
@@ -222,6 +222,9 @@ class RoboticsMultiagentMappingExtension(omni.ext.IExt):
             print(f"[Extension] Error during spawning: {e}")
 
     def reset_robots_to_initial_positions(self):
+        # Stop Simulation and reset ROS2
+        reset_simulation_and_ros2()
+
         if self.robot_spawner:
             self.robot_spawner.reset_to_initial_positions()
             print("[Extension] Robots reset to initial positions.")
@@ -230,6 +233,9 @@ class RoboticsMultiagentMappingExtension(omni.ext.IExt):
 
     def reset(self):
         try:
+            # Stop Simulation and reset ROS2
+            reset_simulation_and_ros2()
+
             # Reset the USD world by removing the /World prim
             stage = omni.usd.get_context().get_stage()
             if stage.GetPrimAtPath("/World"):

--- a/isaacsim_extension/exts/robotics.multiagent.mapping/robotics/multiagent/mapping/utils.py
+++ b/isaacsim_extension/exts/robotics.multiagent.mapping/robotics/multiagent/mapping/utils.py
@@ -1,0 +1,20 @@
+import omni.kit.commands
+import subprocess
+from omni.timeline import get_timeline_interface
+
+def reset_simulation_and_ros2():
+    try:
+        # Get the timeline interface
+        timeline = get_timeline_interface()
+
+        # Pause and stop the simulation using context management
+        if timeline.is_playing():
+            timeline.stop()
+            print("[Extension] Simulation stopped.")
+
+        # Run the bash script to reset ROS2 nodes
+        subprocess.call(["bash", "stop_all_ros2_nodes.sh"])
+        print("[Extension] ROS2 nodes reset.")
+
+    except Exception as e:
+        print(f"[Extension] Error during reset: {e}")

--- a/isaacsim_extension/exts/robotics.multiagent.mapping/robotics/stop_all_ros2_nodes.bash
+++ b/isaacsim_extension/exts/robotics.multiagent.mapping/robotics/stop_all_ros2_nodes.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# List all active ROS 2 nodes
+ros2 node list
+
+# Stop all ROS 2 nodes by killing related processes
+pkill -f ros2
+killall -9 python3
+killall -9 ros2
+
+# Stop ROS 2 daemon
+ros2 daemon stop
+
+# Start ROS2 daemon
+ros2 daemon start
+
+# Verify if any nodes are still running
+ros2 node list
+
+echo "All ROS 2 nodes have been terminated."


### PR DESCRIPTION
# Pull Request: Simulation and ROS2 Reset Updates

## **Overview**
This pull request includes updates to enhance the reset functionality within the Isaac Sim environment. The changes ensure seamless resetting of ROS2 nodes and automatic stopping of the simulation when any reset button is pressed.

---

## **Changes Made**
1. **Unified Reset Functionality:**
   - Added a reusable function `reset_simulation_and_ros2()` that:
     - Pauses and stops the simulation using the Isaac Sim timeline interface.
     - Executes a bash script (`stop_all_ros2_nodes.bash`) to reset ROS2 nodes.
   - Ensures consistency across different reset actions.

2. **Updated Reset Buttons Behavior:**
   - Modified both **Reset** and **Reset Robots** buttons to call the unified `reset_simulation_and_ros2()` function.
   - Ensures both buttons stop the simulation and reset ROS2 nodes when pressed.

3. **Context-Based Simulation Control:**
   - Utilized the **timeline interface** from `omni.timeline` to manage simulation states safely.
   - Ensures robust handling of simulation state transitions without dependency on deprecated methods.

---

## **Key Features**
- **Automatic Simulation Stop:** Prevents unintended simulation play state during resets.
- **ROS2 Nodes Reset:** Ensures clean reset of ROS2 nodes, avoiding conflicts during reinitialization.
- **Reusability:** Centralized reset logic improves maintainability and reduces code duplication.

---

## **Test Plan**
- Verified the simulation stops properly when either reset button is pressed.
- Confirmed ROS2 nodes are reset by observing node shutdown and restart behavior.
- Tested with multiple robot setups to ensure consistency.

---

## **Files Changed**
- Added **utils.py**
- **utils.py:** Added `reset_simulation_and_ros2()` function.
- **extension.py:** Updated reset button logic to call the new function.
- **stop_all_ros2_nodes.bash:** Bash script for resetting ROS2 nodes.

---

## **How to Test**
1. Load the extension in Isaac Sim.
2. Add robots and start the simulation.
3. Press **Reset** or **Reset Robots** buttons.
4. Verify that:
   - Simulation stops immediately.
   - ROS2 nodes are reset.
   - Simulation is ready for reinitialization.

---

## **Notes**
- Ensure `stop_all_ros2_nodes.bash` is executable (`chmod +x stop_all_ros2_nodes.sh`).
- Requires Isaac Sim environment with ROS2 integration.

---

## **Ready for Review**
Please review and provide feedback or suggestions for improvements.

## Summary by Sourcery

Stop the simulation and reset ROS 2 nodes when the "Reset" or "Reset Robots" buttons are pressed.

New Features:
- Implement a unified reset function that stops the running simulation and resets all ROS 2 nodes.

Tests:
- Test the reset functionality with multiple robot setups.