### PR TITLE
Static tf publisher

### DIFF
--- a/ros_packages/tf/tf_static_publisher/CMakeLists.txt
+++ b/ros_packages/tf/tf_static_publisher/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.8)
+project(tf_static_publisher)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(nlohmann_json REQUIRED)
+
+add_executable(static_tf_publisher src/static_tf_publisher.cpp)
+target_include_directories(static_tf_publisher PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+target_compile_features(static_tf_publisher PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+ament_target_dependencies(
+  static_tf_publisher
+  "rclcpp"
+  "geometry_msgs"
+  "std_msgs"
+  "tf2_ros"
+  "nlohmann_json"
+)
+
+install(TARGETS static_tf_publisher
+  DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/ros_packages/tf/tf_static_publisher/README.md
+++ b/ros_packages/tf/tf_static_publisher/README.md
@@ -1,0 +1,100 @@
+# tf_static_publisher
+
+## Overview
+The **tf_static_publisher** package publishes **static transforms** between the `world` frame and each robot's `odom` frame. The robot positions and orientations are loaded automatically from a JSON file stored at:
+```
+/home/regastation/workspaces/masters_ws/src/Multi-Agent_Mapping/initial_positions.json
+```
+
+This package integrates seamlessly with `tf_relay` and `tf_republisher` to manage transforms in multi-robot systems.
+
+---
+
+## Dependencies
+- ROS 2 (Galactic or newer)
+- `rclcpp`
+- `tf2_ros`
+- `geometry_msgs`
+- `nlohmann_json`
+
+---
+
+## Topics
+
+### **Input Topics**
+This node does **not** subscribe to any input topics. Instead, it reads robot position and rotation data from the JSON file.
+
+### **Output Topics**
+1. **`/tf_static`** (type: `tf2_msgs/msg/TFMessage`)
+   - Publishes static transforms for each robot in the format:
+     ```
+     world -> <robot_namespace>/odom
+     ```
+   - Example transform for `scout_1`:
+     ```
+     world -> scout_1/odom
+     ```
+
+---
+
+## JSON File Format
+The JSON file should define robot namespaces, positions, and rotations as shown below:
+```json
+{
+    "robot_1": {
+        "namespace": "scout_1",
+        "position": {
+            "x": 3.373275817938868,
+            "y": -3.0545295297177084,
+            "z": -6.869831537606653e-05
+        },
+        "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+        }
+    }
+}
+```
+
+---
+
+## Running the Package
+1. **Build the Package:**
+   ```bash
+   colcon build --packages-select tf_static_publisher
+   ```
+
+2. **Source the Environment:**
+   ```bash
+   source install/setup.bash
+   ```
+
+3. **Run the Node:**
+   ```bash
+   ros2 run tf_static_publisher static_tf_publisher
+   ```
+
+---
+
+## Verification
+1. **TF Tree Visualization:**
+   ```bash
+   ros2 run tf2_tools view_frames
+   ```
+2. **Inspect Specific Transform:**
+   ```bash
+   ros2 run tf2_ros tf2_echo world scout_1/odom
+   ```
+
+---
+
+## License
+This package is distributed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
+
+---
+
+## Contact
+For issues or contributions, contact **regastation**.
+

--- a/ros_packages/tf/tf_static_publisher/package.xml
+++ b/ros_packages/tf/tf_static_publisher/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>tf_static_publisher</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="ashok.kumarj@icloud.com">regastation</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>nlohmann_json</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros_packages/tf/tf_static_publisher/src/static_tf_publisher.cpp
+++ b/ros_packages/tf/tf_static_publisher/src/static_tf_publisher.cpp
@@ -1,0 +1,100 @@
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2_ros/static_transform_broadcaster.h>
+#include <nlohmann/json.hpp>
+#include <fstream>
+#include <string>
+
+using json = nlohmann::json;
+
+class StaticTFPublisher : public rclcpp::Node
+{
+public:
+    StaticTFPublisher() : Node("static_tf_publisher")
+    {
+        // Enable sim time param
+        this->declare_parameter("use_sim_time", true);
+
+        // Use fixed absolute path for JSON file
+        std::string json_file = "/home/regastation/workspaces/masters_ws/src/MultiAgentMapping/initial_positions.json";
+
+        // Load and publish static transforms
+        load_and_publish(json_file);
+    }
+
+private:
+    std::shared_ptr<tf2_ros::StaticTransformBroadcaster> broadcaster_;
+
+    void load_and_publish(const std::string &json_file)
+    {
+        // Load JSON file
+        std::ifstream file(json_file);
+        if (!file.is_open())
+        {
+            RCLCPP_ERROR(this->get_logger(), "Failed to open JSON file: %s", json_file.c_str());
+            return;
+        }
+
+        json robots;
+        file >> robots;
+
+        // Initialize static transform broadcaster
+        broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
+
+        // Publish static transforms for each robot
+        for (auto &robot : robots.items())
+        {
+            std::string robot_name = robot.key();
+            std::string namespace_ = robot.value()["namespace"];
+
+            // Read position
+            double x = robot.value()["position"]["x"];
+            double y = robot.value()["position"]["y"];
+            double z = robot.value()["position"]["z"];
+
+            // Read rotation
+            double qx = robot.value()["rotation"]["x"];
+            double qy = robot.value()["rotation"]["y"];
+            double qz = robot.value()["rotation"]["z"];
+            double qw = robot.value()["rotation"]["w"];
+
+            // Publish transform
+            publish_static_tf(namespace_, x, y, z, qx, qy, qz, qw);
+        }
+    }
+
+    void publish_static_tf(const std::string &ns,
+                           double x, double y, double z,
+                           double qx, double qy, double qz, double qw)
+    {
+        geometry_msgs::msg::TransformStamped t;
+
+
+        // Use ROS Sim time
+        t.header.stamp = this->get_clock()->now();
+        t.header.frame_id = "world";
+        t.child_frame_id = ns + "/odom"; // Use namespace in frame_id
+
+        // Set position
+        t.transform.translation.x = x;
+        t.transform.translation.y = y;
+        t.transform.translation.z = z;
+
+        // Set rotation (quaternion)
+        t.transform.rotation.x = qx;
+        t.transform.rotation.y = qy;
+        t.transform.rotation.z = qz;
+        t.transform.rotation.w = qw;
+
+        broadcaster_->sendTransform(t);
+        RCLCPP_INFO(this->get_logger(), "Published static transform: world -> %s/odom", ns.c_str());
+    }
+};
+
+int main(int argc, char **argv)
+{
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<StaticTFPublisher>());
+    rclcpp::shutdown();
+    return 0;
+}

--- a/ros_packages/tf/tf_static_publisher/src/static_tf_publisher.cpp
+++ b/ros_packages/tf/tf_static_publisher/src/static_tf_publisher.cpp
@@ -12,9 +12,6 @@ class StaticTFPublisher : public rclcpp::Node
 public:
     StaticTFPublisher() : Node("static_tf_publisher")
     {
-        // Enable sim time param
-        this->declare_parameter("use_sim_time", true);
-
         // Use fixed absolute path for JSON file
         std::string json_file = "/home/regastation/workspaces/masters_ws/src/MultiAgentMapping/initial_positions.json";
 


### PR DESCRIPTION
# tf_static_publisher

## Overview
`tf_static_publisher` is a ROS 2 package designed to publish static transforms between frames. It provides a static transform publisher that publishes a `tf_static` transform between the `world` frame and the `robot_x/odom` frame.

## Features
- Publishes a static transform between specified frames.
- Easy to configure and extend for other transforms.

## Usage
To launch the static transform publisher, run:

```bash
ros2 run tf_static_publisher static_tf_publisher
```

## Summary by Sourcery

Add a node to publish static transforms for multi-robot systems.

New Features:
- Publish static transforms between the "world" frame and each robot\'s "odom" frame, loading robot positions from a JSON file.

Tests:
- Verify the transforms using `view_frames` and `tf2_echo`.